### PR TITLE
Outfitter fix for slasher

### DIFF
--- a/gamemodes/slashco/gamemode/init.lua
+++ b/gamemodes/slashco/gamemode/init.lua
@@ -69,6 +69,7 @@ include("sh_fog.lua")
 include("sv_holylib.lua")
 include("sv_maptools.lua")
 include("sh_keyboard.lua")
+include("sv_outfitter_block.lua")
 
 --Initialize global variable to hold functions.
 SlashCo = SlashCo or {}

--- a/gamemodes/slashco/gamemode/sv_lobby.lua
+++ b/gamemodes/slashco/gamemode/sv_lobby.lua
@@ -359,7 +359,15 @@ local function lobbyRoundSetup()
 			end
 		end
 	end
-
+	--OUTFITTER AUTOWEAR CANCEL, idk maybe it's shitty code but on test this works
+	if outfitter then
+		for _, data in pairs(SlashCo.LobbyData.AssignedSlashers) do
+			local ply = player.GetBySteamID64(data.steamid)
+			print("[SlashCo] Delete outfitter autowear data for " .. ply:GetName())
+			ply:SendLua("util.RemovePData(\"0\",\"outfitter_autowear\")")
+		end
+	end
+		
 	SlashCo.LobbyRoundData()
 
 	--Assign the map randomly

--- a/gamemodes/slashco/gamemode/sv_outfitter_block.lua
+++ b/gamemodes/slashco/gamemode/sv_outfitter_block.lua
@@ -1,6 +1,6 @@
 hook.Add("CanOutfit", "SlashCoBlockSlasherOutfitterModelChange", function(ply)
-    if IsValid(ply) and ply:Team() == TEAM_SLASHER then
-        ply:ChatPrint("YOU CAN'T USE CUSTOM MODEL WITH OUTFITTER FOR SLASHER TEAM!")
+    if IsValid(ply) and (ply:Team() == TEAM_SLASHER or ply:Team() == TEAM_SPECTATOR ) then
+        ply:ChatPrint("YOU CAN'T USE CUSTOM MODEL WITH OUTFITTER FOR SLASHER/SPECTATOR TEAM!")
         return false
     end
 end)

--- a/gamemodes/slashco/gamemode/sv_outfitter_block.lua
+++ b/gamemodes/slashco/gamemode/sv_outfitter_block.lua
@@ -1,0 +1,6 @@
+hook.Add("CanOutfit", "SlashCoBlockSlasherOutfitterModelChange", function(ply)
+    if IsValid(ply) and ply:Team() == TEAM_SLASHER then
+        ply:ChatPrint("YOU CAN'T USE CUSTOM MODEL WITH OUTFITTER FOR SLASHER TEAM!")
+        return false
+    end
+end)


### PR DESCRIPTION
Block slasher model change with outfitter
This commit delete autowear data for slasher players and in-game block to change model with outfitter with hooking on CanOutfit hook