### PR TITLE
Add NoChaseLight condition to be able disable the chase light

### DIFF
--- a/gamemodes/slashco/gamemode/ui/cl_survivor_hud.lua
+++ b/gamemodes/slashco/gamemode/ui/cl_survivor_hud.lua
@@ -581,7 +581,8 @@ hook.Add("Think", "Slasher_Chasing_Light", function()
 			continue
 		end
 
-		if not slasher:GetNWBool("InSlasherChaseMode") and not slasher:GetNWBool("SidGunRage") and not slasher:GetNWBool("WatcherRage") then
+		if (not slasher:GetNWBool("InSlasherChaseMode") and not slasher:GetNWBool("SidGunRage") and not slasher:GetNWBool("WatcherRage")) or slasher:GetNWBool("NoChaseLight")
+		then
 			continue
 		end
 


### PR DESCRIPTION
Adds the networked boolean "NoChaseLight" for slashers and adds it to the condition that prevents the chase light from happening.