### PR TITLE
Incorrect check for drawHalo colors

### DIFF
--- a/gamemodes/slashco/gamemode/cl_init.lua
+++ b/gamemodes/slashco/gamemode/cl_init.lua
@@ -209,7 +209,7 @@ function SlashCo.DrawHalo(_ents, color, passes, noZ)
 	local haloColor = colors.red
 	if colors[color] then
 		haloColor = colors[color]
-	elseif type(colors) == "Color" then
+	elseif IsColor(color) then
 		haloColor = color
 	end
 


### PR DESCRIPTION
The color variable isn't checked properly in elseif, causing it to default to red.
This change fixes this issue.